### PR TITLE
support experiment_id in get_experiment

### DIFF
--- a/base/common/logs_handler.py
+++ b/base/common/logs_handler.py
@@ -91,7 +91,7 @@ def get_picsellia_experiment(client: Client) -> Experiment:
         An Experiment instance if experiment_name or experiment_id is provided, else raises a RuntimeError.
 
     Raises:
-        RuntimeError: If experiment_name or experiment_name is not available as an environment variable.
+        RuntimeError: If experiment_name or experiment_id is not available as an environment variable.
     """
 
     if experiment_name := os.environ.get("experiment_name"):


### PR DESCRIPTION
Add possibility to get_experiment using `experiment_id` only, rather than `experiment_name` + `project_token` 
