### PR TITLE
feat: update new picsellia version

### DIFF
--- a/core_utils/requirements.txt
+++ b/core_utils/requirements.txt
@@ -1,3 +1,4 @@
 pycocotools==2.0.6
 ultralytics==8.0.67
 onnx==1.13.0
+picsellia==6.10.3

--- a/core_utils/tests.py
+++ b/core_utils/tests.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import yaml
 from picsellia import Client
 
-from yolov8 import (
+from .yolov8 import (
     get_train_test_eval_datasets_from_experiment,
     write_annotation_file,
     get_prop_parameter,

--- a/core_utils/tests.py
+++ b/core_utils/tests.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import yaml
 from picsellia import Client
 
-from .yolov8 import (
+from yolov8 import (
     get_train_test_eval_datasets_from_experiment,
     write_annotation_file,
     get_prop_parameter,

--- a/rebuild_test.sh
+++ b/rebuild_test.sh
@@ -1,0 +1,11 @@
+docker build . -f yolov8-classification/Dockerfile -t picsellia/training-yolov8-classification:test
+docker push picsellia/training-yolov8-classification:test
+
+#docker build . -f yolov8-detection/Dockerfile -t picsellia/training-yolov8-detection:test
+#docker push picsellia/training-yolov8-detection:test
+#
+#docker build . -f yolov8-segmentation/Dockerfile -t picsellia/training-yolov8-segmentation:test
+#docker push picsellia/training-yolov8-segmentation:test
+#
+#docker build . -f unet-instance-segmentation/Dockerfile -t picsellia/training-unet-segmentation:test
+#docker push picsellia/training-unet-segmentation:test

--- a/unet-instance-segmentation/Dockerfile
+++ b/unet-instance-segmentation/Dockerfile
@@ -4,9 +4,6 @@ COPY ./unet-instance-segmentation/requirements.txt .
 
 ARG REBUILD_ALL
 RUN pip3 install -r ./requirements.txt --no-cache-dir
-ARG REBUILD_PICSELLIA
-
-RUN pip3 install --no-cache-dir picsellia
 
 WORKDIR /experiment
 ENV SM_FRAMEWORK="tf.keras"

--- a/unet-instance-segmentation/requirements.txt
+++ b/unet-instance-segmentation/requirements.txt
@@ -2,7 +2,9 @@ tensorflow==2.10.0
 segmentation-models==1.0.1
 albumentations==1.3.1
 imgaug==0.4.0
-picsellia==6.10.2
+picsellia==6.10.3
 coverage==7.3.1
 fuzzywuzzy==0.18.0
 pycocotools==2.0.7
+coverage==7.3.0
+picsellia==6.10.3

--- a/unet-instance-segmentation/requirements.txt
+++ b/unet-instance-segmentation/requirements.txt
@@ -6,5 +6,4 @@ picsellia==6.10.3
 coverage==7.3.1
 fuzzywuzzy==0.18.0
 pycocotools==2.0.7
-coverage==7.3.0
 picsellia==6.10.3

--- a/update_picsellia_and_test.sh
+++ b/update_picsellia_and_test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <picsellia_version>"
+    exit 1
+fi
+
+picsellia_version="$1"
+
+folders=("yolov8-classification" "yolov8-segmentation-refactored" "yolov8-detection-refactored" "unet-instance-segmentation")
+
+for script_dir in "${folders[@]}"; do
+  if [ -f "$script_dir/requirements.txt" ]; then
+    current_version=$(grep -o 'picsellia==[^ ]*' "$script_dir/requirements.txt")
+    current_version=${current_version#*==}
+
+    if [ "$current_version" = "$picsellia_version" ]; then
+      echo "Version $picsellia_version is already in $script_dir/requirements.txt"
+      exit 1
+    else
+      echo "Updating picsellia version in $script_dir's requirements file from $current_version to $picsellia_version.."
+      # Update the picsellia version in the requirements file
+      sed -i "s/picsellia==.*/picsellia==$picsellia_version/" "$script_dir/requirements.txt"
+    fi
+  else
+    echo "Requirements file not found in $script_dir"
+  fi
+done
+
+./run_unit_tests.sh all
+./rebuild_test.sh
+
+

--- a/yolov8-classification/Dockerfile
+++ b/yolov8-classification/Dockerfile
@@ -4,9 +4,6 @@ COPY ./yolov8-classification/requirements.txt .
 
 ARG REBUILD_ALL
 RUN python3.10 -m pip install -r requirements.txt --no-cache-dir
-ARG REBUILD_PICSELLIA
-
-RUN python3.10 -m pip install picsellia --upgrade
 
 WORKDIR /experiment
 

--- a/yolov8-classification/requirements.txt
+++ b/yolov8-classification/requirements.txt
@@ -3,3 +3,4 @@ ultralytics==8.0.67
 onnx==1.13.1
 scikit-learn==1.2.2
 coverage==7.3.0
+picsellia==6.10.3

--- a/yolov8-detection-refactored/Dockerfile
+++ b/yolov8-detection-refactored/Dockerfile
@@ -4,9 +4,6 @@ COPY ./yolov8-detection-refactored/requirements.txt .
 
 ARG REBUILD_ALL
 RUN python3.10 -m pip install -r requirements.txt --no-cache-dir
-ARG REBUILD_PICSELLIA
-
-RUN python3.10 -m pip install picsellia --upgrade
 
 WORKDIR /experiment
 

--- a/yolov8-detection-refactored/requirements.txt
+++ b/yolov8-detection-refactored/requirements.txt
@@ -1,3 +1,5 @@
 pycocotools==2.0.6
 ultralytics==8.0.48
 onnx==1.13.0
+coverage==7.3.0
+picsellia==6.10.3

--- a/yolov8-segmentation-refactored/Dockerfile
+++ b/yolov8-segmentation-refactored/Dockerfile
@@ -4,9 +4,6 @@ COPY ./yolov8-segmentation-refactored/requirements.txt .
 
 ARG REBUILD_ALL
 RUN python3.10 -m pip install -r requirements.txt --no-cache-dir
-ARG REBUILD_PICSELLIA
-
-RUN python3.10 -m pip install picsellia --upgrade
 
 WORKDIR /experiment
 

--- a/yolov8-segmentation-refactored/requirements.txt
+++ b/yolov8-segmentation-refactored/requirements.txt
@@ -1,3 +1,5 @@
 pycocotools==2.0.6
 ultralytics==8.0.67
 onnx==1.13.0
+coverage==7.3.0
+picsellia==6.10.3


### PR DESCRIPTION
- bash script to modify picsellia version with a new one, install requirements, run unit tests, build and push test images  

- pip install picsellia is now in all requirements files, and removed from dockerfiles. 

This is implemented for the three yolov8 models, and unet model. 