### PR TITLE
feat: added a check to kill run.sh if the log_handler script fails

### DIFF
--- a/base/run.sh
+++ b/base/run.sh
@@ -1,30 +1,46 @@
 #!/bin/bash
 
+# Function to print the usage information for the script
 usage() {
   echo "Usage: $0 filename"
   exit 1
 }
 
+# Function to find the appropriate Python version to use, depending on the chosen model version to train
 get_python() {
   if command -v python3.10 &> /dev/null; then
     echo "python3.10"
-    return 0
   elif command -v python3.8 &> /dev/null; then
     echo "python3.8"
-    return 0
   else
     echo "Neither Python 3.10 nor Python 3.8 is available on the system."
     exit 1
   fi
 }
 
+# Function to monitor the log_handler process
+monitor_log_handler() {
+  while :
+  do
+    # If log_handler has stopped, stop the training script and exit
+    if ! kill -0 "$log_handler_pid" 2> /dev/null; then
+      echo -e "\e[31mError:\e[0m Log handler has terminated unexpectedly. The training script has been stopped to prevent data loss. Please check the provided environment variables."
+      kill "$training_script_pid" 2> /dev/null
+      wait "$training_script_pid" 2> /dev/null
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+# Validate the input arguments
 if [ $# -eq 0 ]; then
-  echo "Error: a filename must be provided."
+  echo "Error: A filename must be provided."
   usage
 fi
 
 if [ ! -e "$1" ]; then
-  echo "Error: The provided filename $1 does not exist inside the current directory."
+  echo "Error: The provided filename $1 does not exist."
   usage
 fi
 
@@ -36,14 +52,27 @@ fi
 log_file_path="/experiment/training.log"
 python_cmd=$(get_python)
 
+# Start the log_handler
 $python_cmd logs/handler.py --log_file_path "$log_file_path" &
-LOG_HANDLER_PID=$!
+log_handler_pid=$!
 
-$python_cmd "$1" > "$log_file_path" 2>&1
-RETURN_CODE=$?
+# Start the log_handler monitoring in the background
+monitor_log_handler &
+log_handler_monitor_pid=$!
 
-echo "--ec-- $RETURN_CODE" >> "$log_file_path"
+# Start the training script
+$python_cmd "$1" > "$log_file_path" 2>&1 &
+training_script_pid=$!
 
-wait "$LOG_HANDLER_PID"
+wait "$training_script_pid"
+training_script_exit_code=$?
 
-exit $RETURN_CODE
+# Stop the monitor as the training script has finished and wait for the log_handler
+kill "$log_handler_monitor_pid" 2> /dev/null
+wait "$log_handler_pid" 2> /dev/null
+
+# Append the exit code of the training script to the log file
+echo "--ec-- $training_script_exit_code" >> "$log_file_path"
+
+# Exit with the exit code of the training script
+exit $training_script_exit_code


### PR DESCRIPTION
Updated run.sh script to handle some edge cases when the log_handler could silently fail in background.
An error message is displayed in the terminal to notify the user that something went wrong: 

![Uploading Screenshot 2023-10-31 at 09.28.23.png…]()
