### PR TITLE
feat: add uv inside base docker images

### DIFF
--- a/base/cpu/Dockerfile
+++ b/base/cpu/Dockerfile
@@ -6,9 +6,11 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 ARG DEBIAN_FRONTEND=noninteractives
 
-RUN if [ "$PYTHON_VERSION" = "3.10" ]; then \ 
+RUN if [ "$PYTHON_VERSION" = "3.10" ]; then \
         python${PYTHON_VERSION} -m ensurepip --upgrade && python${PYTHON_VERSION} -m pip install -U setuptools; \
     fi
+
+RUN pip install uv
 
 COPY ./base /experiment
 

--- a/base/cuda/Dockerfile
+++ b/base/cuda/Dockerfile
@@ -16,11 +16,13 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
 
 
-RUN if [ "$PYTHON_VERSION" = "3.10" ]; then \ 
+RUN if [ "$PYTHON_VERSION" = "3.10" ]; then \
         python${PYTHON_VERSION} -m ensurepip --upgrade && python${PYTHON_VERSION} -m pip install -U setuptools; \
-    elif [ "$PYTHON_VERSION" = "3.8" ]; then \ 
+    elif [ "$PYTHON_VERSION" = "3.8" ]; then \
         python${PYTHON_VERSION} -m pip install --upgrade pip && pip3 install -U setuptools; \
     fi
+
+RUN pip install uv
 
 ENV PATH="/usr/local/cuda/bin:${PATH}" \
     LD_LIBRARY_PATH="/usr/local/cuda/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
## Description
Configure the base image and add uv so that the base images are properly configured to build the new training images.

## Issues
This PR resolves #104 

## What's new?
- uv installed in the base docker images

- Documentation changed:
![image](https://github.com/picselliahq/picsellia-training-engine/assets/91198746/4b5b3b30-2f7e-4447-a9e0-afdad42326f1)

- Docker images pushed: 
![image](https://github.com/picselliahq/picsellia-training-engine/assets/91198746/50237464-d871-40ed-82dc-e2f02815df0d)


