### PR TITLE
fix: stop accumulating progress bar lines

### DIFF
--- a/base/logs/tailer.py
+++ b/base/logs/tailer.py
@@ -61,10 +61,7 @@ class LogTailer:
                 wait_for_done = False
             if not self.progress_bar:
                 is_first_line = True
-            else:
-                self.progress_bar[-1] += "\r"
-            self.progress_bar.append(line)
-            line = "".join(self.progress_bar)
+            self.progress_bar = [line]
 
             if "100%" in line:
                 wait_for_done = True


### PR DESCRIPTION
## Description
Stop accumulating lines on progress bars, because it sends a logging line larger each time.
